### PR TITLE
2020-05-19 Enable out-of-source compilation and OS X building.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,11 @@ project(mpc)
 
 set(CMAKE_CXX_STANDARD 14)
 
+IF(APPLE)
+find_package(LLVM REQUIRED CONFIG)
+include_directories(/usr/local/opt/llvm/include)
+string(APPEND CMAKE_CXX_FLAGS " -Wno-c++11-narrowing")
+ENDIF(APPLE)
+
 add_subdirectory(src)
 add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Check `test/example` directory for more examples.
 
 ## Build from Source
 
+**Now both in-source and out-of-source compilation is allowed.**
+
 ### Dependencies
 
 * gcc >= 5.4
@@ -131,6 +133,21 @@ cmake --build <build-dir> --target mpc
     ```
     cmake --build <build-dir> --target mpc-test-example
     ```
+
+### Attention for MacOS Users
+1. Use `homebrew` to install `llvm`.
+``` shell
+brew install llvm
+```
+2. Follow hints in `brew info llvm`, implement
+``` shell
+echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
+```
+3. Use `homebrew` to install `coreutils`
+``` shell
+brew install coreutils
+```
+Building Steps are totally same as above.
 
 ## Documentation
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,8 +76,12 @@ add_custom_command(
         DEPENDS ${CMAKE_CURRENT_LIST_DIR}/bison/head.y ${BISON_SOURCE} ${CMAKE_CURRENT_LIST_DIR}/bison/build.sh
 )
 
+if(APPLE)
+llvm_map_components_to_libnames(LLVM_LINK_LIBRARIES core)
+ELSE()
 execute_process(COMMAND llvm-config --libs OUTPUT_VARIABLE LLVM_LINK_LIBRARIES)
 string(STRIP "${LLVM_LINK_LIBRARIES}" LLVM_LINK_LIBRARIES)
+ENDIF()
 
 add_executable(
         mpc
@@ -85,4 +89,5 @@ add_executable(
         ${CMAKE_CURRENT_BINARY_DIR}/pascal.l.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/pascal.y.cpp ${CMAKE_CURRENT_BINARY_DIR}/pascal.y.hpp
 )
+
 set_target_properties(mpc PROPERTIES LINK_LIBRARIES "${LLVM_LINK_LIBRARIES}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,19 +6,19 @@ add_custom_target(
 )
 
 add_custom_target(
-        mpc-test-normal bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ok.sh ${CMAKE_BINARY_DIR}/src/mpc normal
+        mpc-test-normal bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ok.sh ${PROJECT_BINARY_DIR}/src/mpc normal
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS mpc
 )
 
 add_custom_target(
-        mpc-test-example bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ok.sh ${CMAKE_BINARY_DIR}/src/mpc example
+        mpc-test-example bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ok.sh ${PROJECT_BINARY_DIR}/src/mpc example
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS mpc
 )
 
 add_custom_target(
-        mpc-test-validation bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ce.sh ${CMAKE_BINARY_DIR}/src/mpc validation
+        mpc-test-validation bash ${CMAKE_CURRENT_SOURCE_DIR}/test_ce.sh ${PROJECT_BINARY_DIR}/src/mpc validation
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS mpc
 )

--- a/test/test_ce.sh
+++ b/test/test_ce.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+OS_Type=`uname`
+if [ $OS_Type -eq "Darwin" ]
+then
+    alias timeout=gtimeout
+fi
+
 mpc=$1
 dir=$2
 TIMEOUT=5

--- a/test/test_ok.sh
+++ b/test/test_ok.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+OS_Type=`uname`
+if [ $OS_Type -eq "Darwin" ]
+then
+    alias timeout=gtimeout
+fi
+
 mpc=$1
 dir=$2
 TIMEOUT=5


### PR DESCRIPTION
Hello Tsr !!

We are working on this year's Compiling Principle Project. I tried to use your repo for environment building and found a lot of errors on `MacOS`, LOL.
Eventually, I managed to build this project on my **OS X system** in an **out-of-source** compilation way.  Since your repo is an extremely important material for learning, I decided to restrict my changes to the bash files and CMakeLists, then merge my codes to your repo.
I hope you can accept my pull-request and make your compiler a better cross-platform project. This is also my first pull-request, LOL.

Best Regards!
